### PR TITLE
Include Fuzzy XML parser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem "codeclimate-test-reporter", group: :test, require: nil
 
 group :test, :development do
   gem "guard"
-  gem 'guard-rspec'
+  gem "guard-rspec"
 
   gem "rb-inotify", require: false
   gem "rb-fsevent", require: false

--- a/lib/retsy/client/http.rb
+++ b/lib/retsy/client/http.rb
@@ -4,6 +4,7 @@ require "faraday/digestauth"
 require "faraday/conductivity"
 require "faraday-cookie_jar"
 require "retsy/middleware/rets_request_id"
+require "retsy/middleware/fuzzy_xml"
 require "retsy/middleware/nori_xml"
 
 
@@ -18,6 +19,7 @@ module Retsy
           builder.request :request_headers, accept: "application/xml"
 
           builder.response :nori_xml, content_type: /\bxml$/
+          builder.response :fuzzy_xml
 
           builder.use :cookie_jar
           builder.adapter(Faraday.default_adapter)

--- a/lib/retsy/middleware/fuzzy_xml.rb
+++ b/lib/retsy/middleware/fuzzy_xml.rb
@@ -1,0 +1,24 @@
+module Retsy
+  module Middleware
+    class FuzzyXml < Faraday::Response::Middleware
+      def call(env)
+        @app.call(env).on_complete do |res|
+          content_type = res.response_headers[:content_type]
+          unless content_type =~ /\bxml$/
+            if res.body =~ /^</
+              res.response_headers[:content_type] = "application/xml"
+            end
+          end
+        end
+      end
+
+      def initialize(app, _options = {})
+        super(app)
+      end
+    end
+  end
+end
+
+Faraday::Response.register_middleware(
+  fuzzy_xml: Retsy::Middleware::FuzzyXml
+)

--- a/spec/retsy/client/http_spec.rb
+++ b/spec/retsy/client/http_spec.rb
@@ -13,6 +13,7 @@ module Retsy
             Faraday::Request::DigestAuth,
             Faraday::Conductivity::RequestHeaders,
             Retsy::Middleware::NoriXml,
+            Retsy::Middleware::FuzzyXml,
             Faraday::CookieJar,
             Faraday::Adapter::NetHttp,
           ]

--- a/spec/retsy/middleware/fuzzy_xml_spec.rb
+++ b/spec/retsy/middleware/fuzzy_xml_spec.rb
@@ -1,0 +1,35 @@
+require "spec_helper"
+require "retsy/middleware/fuzzy_xml"
+
+module Retsy
+  module Middleware
+    describe FuzzyXml, type: :middleware do
+      let(:body) do
+        '<RETS ReplyCode="0" ReplyText="Login Request">' \
+          "<RETS-RESPONSE>" \
+          "</RETS-RESPONSE>" \
+        "<RETS>"
+      end
+
+      context "XML content with xml content type" do
+        let(:content_type) { "application/xml" }
+        let(:expected_content_type) { "application/xml" }
+
+        it "leaves content for correct response" do
+          expect(process(body, content_type).headers[:content_type]).
+            to eq(expected_content_type)
+        end
+      end
+
+      context "XML content with text/plain content type" do
+        let(:content_type) { "text/plain" }
+        let(:expected_content_type) { "application/xml" }
+
+        it "leaves content for correct response" do
+          expect(process(body, content_type).headers[:content_type]).
+            to eq(expected_content_type)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently some servers return XML content with text/plain content type.

The current solution is: parse text/plain as xml (which is a very bad solution).

The better solution would be:

Check if content is XML (by analysing if it starts with "<xml") and then rewrite the content-type
